### PR TITLE
[HB-6923] Use canShow method instead of isLoaded

### DIFF
--- a/BidMachineAdapter/build.gradle.kts
+++ b/BidMachineAdapter/build.gradle.kts
@@ -36,7 +36,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.2.4.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.2.4.0.1"
         buildConfigField("String", "CHARTBOOST_MEDIATION_BIDMACHINE_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")

--- a/BidMachineAdapter/src/main/java/com/chartboost/mediation/bidmachineadapter/BidMachineAdapter.kt
+++ b/BidMachineAdapter/src/main/java/com/chartboost/mediation/bidmachineadapter/BidMachineAdapter.kt
@@ -788,8 +788,8 @@ class BidMachineAdapter : PartnerAdapter {
                 Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_SHOW_FAILURE_AD_NOT_FOUND))
             }
 
-            is InterstitialAd -> canShowAd(ad::isLoaded, ad::show)
-            is RewardedAd -> canShowAd(ad::isLoaded, ad::show)
+            is InterstitialAd -> canShowAd(ad::canShow, ad::show)
+            is RewardedAd -> canShowAd(ad::canShow, ad::show)
 
             else -> {
                 PartnerLogController.log(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,8 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.2.4.0.1
+- Use BidMachine's `canShow` instead of `isLoaded` before displaying ad.
+
 ### 4.2.4.0.0
 - This version of the adapter has been certified with BidMachine Ads SDK 2.4.0.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation BidMachine adapter mediates BidMachine via the Chartboo
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-bidmachine:4.2.4.0.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-bidmachine:4.2.4.0.1"
 ```
 
 ## Contributions


### PR DESCRIPTION
- Switched `isLoaded` method with `canShow` method before displaying fullscreen ads.
- Updated Changelog, README, build script to 4.2.4.0.1